### PR TITLE
How to fix and normalize SSH access to FLSUN T1 after using exploit to log in

### DIFF
--- a/FLSUN T1 - T1 Pro/Restore normal SSH access to FLSUN T1 after using exploit
+++ b/FLSUN T1 - T1 Pro/Restore normal SSH access to FLSUN T1 after using exploit
@@ -1,0 +1,192 @@
+This requires that you first use the exploit found here to SSH in: https://github.com/Guilouz/Flsun-S1-T1/blob/main/README.md
+
+From there, follow the instructions below to restore normal SSH access. 
+
+So first off, the reason flsun are able to ship the T1 and T1 Pro with klipper already working out of the box, is that they essentially use the touch pad that comes with the T1 as a Raspberry Pi. That touchpad is what we are SSHing into, and is also what has klipper installed onto it. I am not 100% sure exactly what the hardware it however. 
+
+So my first goal when SSHing Inc into the T1. was to figure out a way to secure access to the T1 so that I didn't have to use this exploit every time. To me, that was important because I own the device and Kilpper is open source, and I don't feel like flsun should be applying these kind of security measures to prevent people from logging in. In order to normalize access to ssh, I decided my best bet would be to purge ssh and reinstall it. The problem was that every time I purged it or reinstalled it, It would still prevent access to ssh.
+
+Then I noticed that ssh was being masked, and it was that mask that was causing this access issue:
+
+pi@FLSunT1:~$ sudo systemctl status ssh
+● ssh.service
+   Loaded: masked (Reason: Unit ssh.service is masked.)
+   Active: inactive (dead) since Mon 2024-12-09 20:24:24 MST; 
+
+The mask would reapply itself. anytime that ssh was reinstalled or purge. So at that point, I started looking for scripts. Specifically,  security scripts that would mask SSH based on some sort of action.
+It took me a little while to find.
+
+For example, I didn't see any scripts here:
+pi@FLSunT1:~$ grep -r 'systemctl mask ssh' /var/lib/dpkg/info/
+pi@FLSunT1:~$
+
+But eventually I found what I was looking for:
+
+pi@FLSunT1:~$ grep -r 'mask' /var/lib/dpkg/info
+/var/lib/dpkg/info/openssh-server.postrm:               deb-systemd-helper mask 'ssh.socket' >/dev/null || true
+/var/lib/dpkg/info/openssh-server.postrm:               deb-systemd-helper unmask 'ssh.socket' >/dev/null || true
+/var/lib/dpkg/info/openssh-server.postrm:               deb-systemd-helper mask 'ssh.service' >/dev/null || true
+/var/lib/dpkg/info/openssh-server.postrm:               deb-systemd-helper unmask 'ssh.service' >/dev/null || true
+/var/lib/dpkg/info/unattended-upgrades.postinst:        # This will only remove masks created by d-s-h on package removal.
+/var/lib/dpkg/info/unattended-upgrades.postinst:        deb-systemd-helper unmask 'unattended-upgrades.service' >/dev/null || true
+/var/lib/dpkg/info/openbsd-inetd.postinst:      # This will only remove masks created by d-s-h on package removal.
+/var/lib/dpkg/info/openbsd-inetd.postinst:      deb-systemd-helper unmask 'inetd.service' >/dev/null || true
+/var/lib/dpkg/info/openbsd-inetd.postrm:                deb-systemd-helper mask 'inetd.service' >/dev/null || true
+/var/lib/dpkg/info/openbsd-inetd.postrm:                deb-systemd-helper unmask 'inetd.service' >/dev/null || true
+/var/lib/dpkg/info/openssh-client.postinst:umask 022
+/var/lib/dpkg/info/unattended-upgrades.postrm:          deb-systemd-helper mask 'unattended-upgrades.service' >/dev/null || true
+/var/lib/dpkg/info/unattended-upgrades.postrm:          deb-systemd-helper unmask 'unattended-upgrades.service' >/dev/null || true
+/var/lib/dpkg/info/openssh-server.postinst:umask 022
+/var/lib/dpkg/info/openssh-server.postinst:     # This will only remove masks created by d-s-h on package removal.
+/var/lib/dpkg/info/openssh-server.postinst:     deb-systemd-helper unmask 'ssh.service' >/dev/null || true
+/var/lib/dpkg/info/openssh-server.postinst:             # This will only remove masks created by d-s-h on package removal.
+/var/lib/dpkg/info/openssh-server.postinst:             deb-systemd-helper unmask 'ssh.socket' >/dev/null || true
+pi@FLSunT1:~$ ^C
+
+
+
+These are 100% overzealous security measures to put in place for an open source program.. but I found it kind of killariouos and a bit maniacal. 
+
+pi@FLSunT1:~$ sudo nano /var/lib/dpkg/info/openssh-server.postrm
+#!/bin/sh
+set -e
+
+# Automatically added by dh_installinit/12.1.1
+if [ "$1" = "purge" ] ; then
+        update-rc.d ssh remove >/dev/null
+udo nano /var/lib/dpkg/info/openssh-server.postrmfi
+# End automatically added section
+# Automatically added by dh_installdeb/12.1.1
+dpkg-maintscript-helper rm_conffile /etc/network/if-up.d/openssh-server 1:7.9p1-1~ -- "$@"
+# End automatically added section
+# Automatically added by dh_installdeb/12.1.1
+dpkg-maintscript-helper rm_conffile /etc/init/ssh.conf 1:7.5p1-6~ -- "$@"
+# End automatically added section
+# Automatically added by dh_installdeb/12.1.1
+dpkg-maintscript-helper mv_conffile /etc/pam.d/ssh /etc/pam.d/sshd 1:4.7p1-4~ -- "$@"
+# End automatically added section
+# Automatically added by dh_systemd_start/12.1.1
+if [ -d /run/systemd/system ]; then
+        systemctl --system daemon-reload >/dev/null || true
+fi
+# End automatically added section
+# Automatically added by dh_systemd_enable/12.1.1
+if [ "$1" = "remove" ]; then
+        if [ -x "/usr/bin/deb-systemd-helper" ]; then
+                deb-systemd-helper mask 'ssh.socket' >/dev/null || true
+        fi
+fi
+
+if [ "$1" = "purge" ]; then
+        if [ -x "/usr/bin/deb-systemd-helper" ]; then
+                deb-systemd-helper purge 'ssh.socket' >/dev/null || true
+                deb-systemd-helper unmask 'ssh.socket' >/dev/null || true
+        fi
+fi
+# End automatically added section
+# Automatically added by dh_systemd_enable/12.1.1
+if [ "$1" = "remove" ]; then
+        if [ -x "/usr/bin/deb-systemd-helper" ]; then
+                deb-systemd-helper mask 'ssh.service' >/dev/null || true
+        fi
+fi
+
+if [ "$1" = "purge" ]; then
+        if [ -x "/usr/bin/deb-systemd-helper" ]; then
+                deb-systemd-helper purge 'ssh.service' >/dev/null || true
+                deb-systemd-helper unmask 'ssh.service' >/dev/null || true
+        fi
+fi
+# End automatically added section
+# Automatically added by dh_installdebconf/12.1.1
+if [ "$1" = purge ] && [ -e /usr/share/debconf/confmodule ]; then
+        . /usr/share/debconf/confmodule
+        db_purge
+fi
+# End automatically added section
+
+
+
+=================================================================
+if [ "$1" = "remove" ]; then
+    if [ -x "/usr/bin/deb-systemd-helper" ]; then
+        deb-systemd-helper mask 'ssh.service' >/dev/null || true
+    fi
+fi
+=================================================================
+^ This ensures ssh.service gets masked every time the package is removed, regardless of whether you intend to re-enable it.
+
+
+=================================================================
+if [ "$1" = "purge" ]; then
+    if [ -x "/usr/bin/deb-systemd-helper" ]; then
+        deb-systemd-helper purge 'ssh.service' >/dev/null || true
+        deb-systemd-helper unmask 'ssh.service' >/dev/null || true
+    fi
+fi
+=================================================================
+^ This only unmasks SSH if you perform a complete purge, however It doesn’t address masking during a simple removal or reinstallation.
+
+
+The cool thing about locating these scripts, is that now that we know where they are and what they are doing,
+we can shut them down so that we have normal access to our printers that we own!
+
+
+
+How to fix this?:
+
+sudo nano /var/lib/dpkg/info/openssh-server.postrm   (This logs you into the script file, which is a text file.. and allows you to edit it)
+
+
+
+Once in, you want to comment out the lines that are doing bad stuff:
+
+# if [ "$1" = "remove" ]; then
+#     if [ -x "/usr/bin/deb-systemd-helper" ]; then
+#         deb-systemd-helper mask 'ssh.service' >/dev/null || true
+#     fi
+# fi
+
+
+# if [ "$1" = "purge" ]; then
+#     if [ -x "/usr/bin/deb-systemd-helper" ]; then
+#         deb-systemd-helper purge 'ssh.service' >/dev/null || true
+#         deb-systemd-helper unmask 'ssh.service' >/dev/null || true
+#     fi
+# fi
+
+Then exit the text editor (crtl+O, Enter, Ctrl + X)
+
+After modifying the script, reconfigure the openssh-server package to apply the changes:
+
+sudo dpkg --configure -a
+
+
+The next step is to unmask SSH and restart it: 
+
+sudo systemctl unmask ssh
+sudo systemctl enable ssh
+sudo systemctl start ssh
+
+Then you want to check the status of SSH to ensure it is functioning normalls and is no longer masked
+
+pi@FLSunT1:~$ sudo systemctl status ssh
+● ssh.service - OpenBSD Secure Shell server
+   Loaded: loaded (/lib/systemd/system/ssh.service; enabled; vendor preset: enabled)
+   Active: active (running) since Mon 2024-12-09 20:55:25 MST; 1h 16min ago
+     Docs: man:sshd(8)
+           man:sshd_config(5)
+ Main PID: 393 (sshd)
+   CGroup: /system.slice/ssh.service
+           └─393 /usr/sbin/sshd -D
+
+Dec 09 20:55:25 FLSunT1 systemd[1]: Starting OpenBSD Secure Shell server...
+Dec 09 20:55:25 FLSunT1 sshd[393]: Server listening on 0.0.0.0 port 22.
+Dec 09 20:55:25 FLSunT1 systemd[1]: Started OpenBSD Secure Shell server.
+
+
+If it looks similar to mine, then congratulations you can now SSH in like you would any device running Klipper, 
+without having to use an exploit to log into your own stuff!
+
+I did all of this a few days ago, and I have since deleted the exploit configuration files needed to SSH in for the first time.
+As of the time of this post, I still have SSH access. 


### PR DESCRIPTION
I go over how flsun are blocking SSH access to the T1 and how to fix it so that you no longer need to use an exploit to log into your T1 and T1 pro printer. **This will require you to use the exploit (see the main README on this repo) initially before you can repair SSH.** 